### PR TITLE
Fix / Optimistic lock on transactions

### DIFF
--- a/src/services/balance.service.js
+++ b/src/services/balance.service.js
@@ -55,15 +55,25 @@ class BalanceService {
              *
              * I gotta talk to the P.O to understand if it'll be deducted of the balance from person who's doing the request.
              */
-            await Profile.increment('balance', { by: amount, where: { id: receiverProfileId }, lock: true, transaction: t });
+            const profile = await Profile.findOne({ where: { id: receiverProfileId } });
+
+            await Profile.increment('balance', {
+                by: amount,
+                where: {
+                    id: receiverProfileId,
+                    version: profile.version
+                },
+                lock: true,
+                transaction: t
+            });
+
             t.commit();
         } catch (error) {
             await t.rollback();
             return new HttpResponse(422, {
                 error: "We can't process your request right now. Try again."
-            });
+            }, error);
         }
-
 
         const recipientProfile = await Profile.findOne({
             where: {


### PR DESCRIPTION
# What's in this PR

## References

N/A <!-- Link any other source of information if necessary -->

## Description

I was stress testing my endpoints and got to know that my optimistic locking implementation was not working properly, thought [sequelize](https://sequelize.org/docs/v6/other-topics/optimistic-locking/#:~:text=Optimistic%20locking%20allows%20concurrent%20access,when%20a%20conflict%20is%20detected.) would handle version control but it does not do that automatically.

Their documentation about it is also really short and I was suspecting the lock version control wasn't working as I wanted. Decided to implement a manual workaround and got it working properly now.

To make things to happen nicely, I really believe plugging a queue service with a retry pattern plus a transaction history would work best!

### Important

N/A <!-- Any important instructions to be able to manual test the content of this PR -->

### TODOs

N/A <!-- Any TODO left for the completion of the task, or additional changes to address in future tasks -->

## QA / Testing

N/A <!-- Tests that were added or done, and screenshots of the result, if applicable -->

## Screenshots

N/A <!-- Screenshot of the visual changes or new component created, if applicable -->
